### PR TITLE
feat: update user type definitions in authStore and user.types for be…

### DIFF
--- a/apps/frontend/src/stores/authStore.ts
+++ b/apps/frontend/src/stores/authStore.ts
@@ -1,11 +1,11 @@
 import { create } from "zustand";
 
 type AuthStatus = "idle" | "checking" | "authenticated" | "unauthenticated";
-
+import { IWebNewUserModel } from "@shared/types/user.types";
 interface AuthState {
   status: AuthStatus;
   isLoggedIn: boolean;
-  user: any | null;
+  user: IWebNewUserModel | null;
   checkAuth: () => Promise<void>;
   performLogout: () => void;
   login: (username: string, password: string) => Promise<boolean>;

--- a/packages/shared/src/types/user.types.ts
+++ b/packages/shared/src/types/user.types.ts
@@ -1,5 +1,11 @@
 import { Document } from "mongoose";
 
+interface IWebNewUserModel {
+  username?: string; // Optional for OAuth users
+  email?: string; // Optional for OAuth users
+  password: string; // Required for local auth, ignored for OAuth
+}
+
 /**
  * This interface defines the shape of a user object when being created (e.g., during registration).
  * Fields like OAuth IDs are optional, as users may sign up through different providers.
@@ -24,4 +30,4 @@ interface IUserDb extends INewUserModel, Document {
   lastLogin?: Date; // Timestamp of last successful login
 }
 
-export { INewUserModel, IUserDb };
+export { IWebNewUserModel, INewUserModel, IUserDb };


### PR DESCRIPTION
Adding types for vercel deployment. Existing error: 

```
2025-06-07T12:50:35.237388107Z ==> Using Bun version 1.1.0 (default)
2025-06-07T12:50:35.237406687Z ==> Docs on specifying a bun version: https://render.com/docs/bun-version
2025-06-07T12:50:35.285280536Z ==> Running build command 'pnpm install --frozen-lockfile; pnpm run build'...
2025-06-07T12:50:48.034861982Z 
2025-06-07T12:50:48.034893302Z > turbo@1.0.0 build /opt/render/project/src
2025-06-07T12:50:48.034899183Z > turbo run build
2025-06-07T12:50:48.034902703Z 
2025-06-07T12:50:48.095070832Z 
2025-06-07T12:50:48.095089752Z Attention:
2025-06-07T12:50:48.095094032Z Turborepo now collects completely anonymous telemetry regarding usage.
2025-06-07T12:50:48.095107443Z This information is used to shape the Turborepo roadmap and prioritize features.
2025-06-07T12:50:48.095111352Z You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
2025-06-07T12:50:48.095115963Z https://turbo.build/repo/docs/telemetry
2025-06-07T12:50:48.095118593Z 
2025-06-07T12:50:48.101014508Z turbo 2.5.0
2025-06-07T12:50:48.101034799Z 
2025-06-07T12:50:48.159504924Z • Packages in scope: backend, frontend
2025-06-07T12:50:48.159527535Z • Running build in 2 packages
2025-06-07T12:50:48.159531475Z • Remote caching disabled
2025-06-07T12:50:48.172245964Z frontend:build: cache miss, executing 824d955976687d78
2025-06-07T12:50:48.544753054Z frontend:build: 
2025-06-07T12:50:48.544772434Z frontend:build: > frontend@0.1.0 build /opt/render/project/src/apps/frontend
2025-06-07T12:50:48.544777464Z frontend:build: > next build
2025-06-07T12:50:48.544781284Z frontend:build: 
2025-06-07T12:50:49.170003227Z frontend:build:    ▲ Next.js 15.2.4
2025-06-07T12:50:49.170432415Z frontend:build: 
2025-06-07T12:50:49.184320147Z frontend:build:    Creating an optimized production build ...
2025-06-07T12:50:56.93671882Z frontend:build:  ✓ Compiled successfully
2025-06-07T12:50:56.972093053Z frontend:build:    Linting and checking validity of types ...
2025-06-07T12:50:57.288625207Z frontend:build:  ⚠ TypeScript project references are not fully supported. Attempting to build in incremental mode.
2025-06-07T12:51:00.707122069Z frontend:build: 
2025-06-07T12:51:00.70714858Z frontend:build: Failed to compile.
2025-06-07T12:51:00.70715422Z frontend:build: 
2025-06-07T12:51:00.7071588Z frontend:build: ./src/stores/authStore.ts
2025-06-07T12:51:00.70716399Z frontend:build: 8:9  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
2025-06-07T12:51:00.70716821Z frontend:build: 
2025-06-07T12:51:00.70717302Z frontend:build: info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
2025-06-07T12:51:00.836728479Z frontend:build:  ELIFECYCLE  Command failed with exit code 1.
2025-06-07T12:51:00.970120533Z frontend:build: ERROR: command finished with error: command (/opt/render/project/src/apps/frontend) /opt/render/.local/share/pnpm/.tools/pnpm/10.7.1/bin/pnpm run build exited (1)
2025-06-07T12:51:00.970307237Z frontend#build: command (/opt/render/project/src/apps/frontend) /opt/render/.local/share/pnpm/.tools/pnpm/10.7.1/bin/pnpm run build exited (1)
2025-06-07T12:51:00.970867878Z 
2025-06-07T12:51:00.970883248Z  Tasks:    0 successful, 1 total
2025-06-07T12:51:00.970886388Z Cached:    0 cached, 1 total
2025-06-07T12:51:00.970889538Z   Time:    12.838s 
2025-06-07T12:51:00.970892388Z Failed:    frontend#build
2025-06-07T12:51:00.970894698Z 
2025-06-07T12:51:00.972894948Z  ERROR  run failed: command  exited (1)
2025-06-07T12:51:01.160168658Z  ELIFECYCLE  Command failed with exit code 1.
2025-06-07T12:51:01.188178127Z ==> Build failed 😞
2025-06-07T12:51:01.188214707Z ==> Common ways to troubleshoot your deploy: https://render.com/docs/troubleshooting-deploys
```